### PR TITLE
solved TokenMismatchException in admin sites on delete row.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -32,6 +32,7 @@ class Kernel extends HttpKernel
             'with_language'
         ],
         'api' => [
+            'web',
             'throttle:60,1',
             'with_language'
         ],


### PR DESCRIPTION
for every datatable on delete button was a token mismatch exception, cuz they are not in same middleware group 'web'.