### PR TITLE
Don't always require password change when editing a user.

### DIFF
--- a/app/Http/Requests/Admin/UserRequest.php
+++ b/app/Http/Requests/Admin/UserRequest.php
@@ -16,7 +16,7 @@ class UserRequest extends Request
         return [
             'email'     => 'required|email|max:255|unique:users,email,'.$this->segment(3),
             'name'      => 'required|string|max:255',
-            'password'  => 'required|min:6|max:20|confirmed',
+            'password'  => 'sometimes|min:6|max:20|confirmed',
             'picture'   => 'sometimes|max:2048|image'
         ];
     }


### PR DESCRIPTION
Requiring the password field was requiring that the password always got changed whenever a user was being edited. `Sometimes` allows you to leave password blank. The `confirmed` attribute will still ensure that confirmation was entered and matches.