### PR TITLE
Update 2015_04_17_083750_add_columns_to_users_table.php

### DIFF
--- a/database/migrations/2015_04_17_083750_add_columns_to_users_table.php
+++ b/database/migrations/2015_04_17_083750_add_columns_to_users_table.php
@@ -13,8 +13,8 @@ class AddColumnsToUsersTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->timestamp('logged_in_at');
-            $table->timestamp('logged_out_at');
+            $table->timestamp('logged_in_at')->nullable();
+            $table->timestamp('logged_out_at')->nullable();
             $table->string('ip_address', 45)->index();
             $table->string('picture');
         });


### PR DESCRIPTION
Hi Friend! I saw that you upgraded the project to Laravel 5.3! That's nice!
During the installation process, on the 4th step of the Quick Install Guide ($ php artisan migrate), an error appears because of the timestamp fields () are blank. Adding 'nullable()' function, the problem is solved.

![ozdemir](https://cloud.githubusercontent.com/assets/5175759/18256684/10dd1e68-738f-11e6-9e8d-30bd7451044c.png)