### PR TITLE
37 console commands

### DIFF
--- a/app/Console/Commands/GenerateResourse.php
+++ b/app/Console/Commands/GenerateResourse.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class GenerateResourse extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'simplecms:generate
+                            {controllerName : The name of controller}
+                            {--schema= : Schema of migration}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command to generate a new resource';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $table_name = strtolower($this->argument('controllerName'));
+        shell_exec("/usr/bin/php artisan make:controller ".$this->argument('controllerName'));
+        if(count($this->option('schema'))!= 0)
+            shell_exec("/usr/bin/php artisan make:migration:schema create_".$table_name."s_table --schema=\"".$this->option('schema')."\"");
+        else
+            shell_exec("/usr/bin/php artisan make:migration create_".$table_name."_table");
+        shell_exec("/usr/bin/php artisan make:request ".$this->argument('controllerName'));
+        shell_exec("/usr/bin/php artisan make:form Forms/".$this->argument('controllerName'));
+        shell_exec("/usr/bin/php artisan migrate");
+        $this->info("New resource generated successfully");
+    }
+}

--- a/app/Console/Commands/GenerateResourse.php
+++ b/app/Console/Commands/GenerateResourse.php
@@ -2,7 +2,9 @@
 
 namespace App\Console\Commands;
 
+use Artisan;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class GenerateResourse extends Command
 {
@@ -13,7 +15,7 @@ class GenerateResourse extends Command
      */
     protected $signature = 'simplecms:generate
                             {controllerName : The name of controller - singular},
-                            {tableName : The name of table - plural}';
+                            {table? : The name of table - plural}';
 
     /**
      * The console command description.
@@ -39,14 +41,14 @@ class GenerateResourse extends Command
      */
     public function handle()
     {
-        $table_name = strtolower($this->argument('tableName'));
-        $form_name = $this->argument('tableName');
+        $table_name = strtolower($this->argument('table') ??
+                      Str::snake(Str::plural($this->argument('controllerName'))));
+        $form_name = $table_name;
         $form_name[0]=strtoupper($form_name[0]);
-        shell_exec("/usr/bin/php artisan make:controller Admin/".$this->argument('controllerName').'Controller');
-        shell_exec("/usr/bin/php artisan make:migration create_".$table_name."_table");
-        shell_exec("/usr/bin/php artisan make:request Admin/".$this->argument('controllerName').'Request');
-        shell_exec("/usr/bin/php artisan make:form Forms/Admin/".$form_name.'Form');
-        shell_exec("/usr/bin/php artisan migrate");
+        Artisan::call("make:controller" , [ 'name' => "Admin/".$this->argument('controllerName').'Controller']);
+        Artisan::call("make:migration" , ['name' => "create_".$table_name."_table"]);
+        Artisan::call("make:request" , ['name' => "Admin/".$this->argument('controllerName').'Request']);
+        Artisan::call("make:form" , ['name' => "Forms/Admin/".$form_name.'Form']);
         $this->info("New resource generated successfully");
     }
 }

--- a/app/Console/Commands/GenerateResourse.php
+++ b/app/Console/Commands/GenerateResourse.php
@@ -12,8 +12,8 @@ class GenerateResourse extends Command
      * @var string
      */
     protected $signature = 'simplecms:generate
-                            {controllerName : The name of controller}
-                            {--schema= : Schema of migration}';
+                            {controllerName : The name of controller - singular},
+                            {tableName : The name of table - plural}';
 
     /**
      * The console command description.
@@ -39,14 +39,13 @@ class GenerateResourse extends Command
      */
     public function handle()
     {
-        $table_name = strtolower($this->argument('controllerName'));
-        shell_exec("/usr/bin/php artisan make:controller ".$this->argument('controllerName'));
-        if(count($this->option('schema'))!= 0)
-            shell_exec("/usr/bin/php artisan make:migration:schema create_".$table_name."s_table --schema=\"".$this->option('schema')."\"");
-        else
-            shell_exec("/usr/bin/php artisan make:migration create_".$table_name."_table");
-        shell_exec("/usr/bin/php artisan make:request ".$this->argument('controllerName'));
-        shell_exec("/usr/bin/php artisan make:form Forms/".$this->argument('controllerName'));
+        $table_name = strtolower($this->argument('tableName'));
+        $form_name = $this->argument('tableName');
+        $form_name[0]=strtoupper($form_name[0]);
+        shell_exec("/usr/bin/php artisan make:controller Admin/".$this->argument('controllerName').'Controller');
+        shell_exec("/usr/bin/php artisan make:migration create_".$table_name."_table");
+        shell_exec("/usr/bin/php artisan make:request Admin/".$this->argument('controllerName').'Request');
+        shell_exec("/usr/bin/php artisan make:form Forms/Admin/".$form_name.'Form');
         shell_exec("/usr/bin/php artisan migrate");
         $this->info("New resource generated successfully");
     }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,7 +12,9 @@ class Kernel extends ConsoleKernel
      *
      * @var array
      */
-    protected $commands = [];
+    protected $commands = [
+        Commands\GenerateResourse::class
+    ];
 
     /**
      * Define the application's command schedule.


### PR DESCRIPTION
#37 Console command:
`php artisan simplecms:generate <controller-name> <table-name>`
`php artisan simplecms:generate Fruit fruits`

I thought is better get 2 arguments controller and table name, because table names are in plural form according to the pattern of laravel. 
