### PR TITLE
Remove password's max-length

### DIFF
--- a/app/Http/Requests/Admin/UserRequest.php
+++ b/app/Http/Requests/Admin/UserRequest.php
@@ -16,7 +16,7 @@ class UserRequest extends Request
         return [
             'email'     => 'required|email|max:255|unique:users,email,'.$this->segment(3),
             'name'      => 'required|string|max:255',
-            'password'  => 'sometimes|min:6|max:20|confirmed',
+            'password'  => 'sometimes|min:6|confirmed',
             'picture'   => 'sometimes|max:2048|image'
         ];
     }


### PR DESCRIPTION
"The Password may not be greater than 20 characters."

[![XKCD Comic 936: Password Strength](https://imgs.xkcd.com/comics/password_strength.png)](https://xkcd.com/936/)